### PR TITLE
Adding pemUTF8 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The plugin configuration JSON file will need to reference the Vault plugin as fo
             "keyStoreFile": "/path/to/keystore/file",
             "keyStorePassword": "keystore_passw0rd",
             "pemFile": "/path/to/pem/file",
+            "pemUTF8": "string contents extracted from the PEM file",
             "clientPemFile": "/path/to/client/pem/file",
             "clientKeyPemFile": "/path/to/client/pem/file"
         }
@@ -76,7 +77,7 @@ The plugin configuration JSON file will need to reference the Vault plugin as fo
 
 Properties `sharedPathRoot` and `privatePathRoot` are optional. Default value for both properties is root (which means `/`).
 
-The `ssl` section is optional and it directly configures [the underlying Vault client](https://github.com/BetterCloud/vault-java-driver#ssl-config).
+The `ssl` section is optional and it directly configures [the underlying Vault client](https://github.com/BetterCloud/vault-java-driver#ssl-config) but only the options documented here are passed through.
 
 In this version, only token-based login is supported. Never use the Vault's initial root token - we recommend creating a separate token with long-enough validity and restricted (read-only) access to secrets.
 

--- a/src/main/scala/com/avast/marathon/plugin/vault/VaultPlugin.scala
+++ b/src/main/scala/com/avast/marathon/plugin/vault/VaultPlugin.scala
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
 
 case class Configuration(address: String, token: String, sharedPathRoot: Option[String], privatePathRoot: Option[String], ssl: Option[SslConfiguration])
 case class SslConfiguration(verify: Option[Boolean], trustStoreFile: Option[String], keyStoreFile: Option[String], keyStorePassword: Option[String],
-                            pemFile: Option[String], clientPemFile: Option[String], clientKeyPemFile: Option[String])
+                            pemFile: Option[String], pemUTF8: Option[String], clientPemFile: Option[String], clientKeyPemFile: Option[String])
 
 class VaultPlugin extends RunSpecTaskProcessor with PluginConfiguration {
 
@@ -39,6 +39,7 @@ class VaultPlugin extends RunSpecTaskProcessor with PluginConfiguration {
       sc.trustStoreFile.foreach(f => sslConfig.trustStoreFile(new File(f)))
       sc.keyStoreFile.foreach(f => sslConfig.keyStoreFile(new File(f), sc.keyStorePassword.getOrElse("")))
       sc.pemFile.foreach(f => sslConfig.pemFile(new File(f)))
+      sc.pemUTF8.foreach(s => sslConfig.pemUTF8(s))
       sc.clientPemFile.foreach(f => sslConfig.clientPemFile(new File(f)))
       sc.clientKeyPemFile.foreach(f => sslConfig.clientKeyPemFile(new File(f)))
     })


### PR DESCRIPTION
The vault client has a (handy) `pemUTF8` function which allows you to inject the cert directly in the json instead of putting it in a file. Took a while to figure out why it wasn't picked up :)